### PR TITLE
Some changes to the build process

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ make -j depend
 if [ ! $deploy ]; then
     make -j $JOBS
 fi
+make depend -C online2_py
 make -j $JOBS -C online2_py
 cd -
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -x
+
+set -e
+JOBS=8
+
+{
+
+echo "Starting build at "`date`
+
+if [[ $1 == '--deploy' ]] ; then
+    echo "Deployment build mode. CUDA will be disabled."
+    cuda_opt="--use-cuda=no"
+    deploy=true
+else
+    echo "Training build mode."
+    deploy=false 
+fi
+   
+cd tools
+extras/check_dependencies.sh
+make clean
+make -j $JOBS
+cd -
+
+cd src
+./configure --openblas-root=../tools/OpenBLAS/install ${cuda_opt}
+make clean
+make -j depend
+make -j $JOBS
+make -C online2_py
+cd -
+
+} > >(tee -a build_stdout.log) 2> >(tee -a build_stderr.log >&2)

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ SUBDIRS_LIB = $(filter-out %bin, $(SUBDIRS))
 KALDI_SONAME ?= libkaldi.so
 
 # Optional subdirectories
-EXT_SUBDIRS = online onlinebin  # python-kaldi-decoding
+EXT_SUBDIRS = online onlinebin online2_py # python-kaldi-decoding
 EXT_SUBDIRS_LIB = $(filter-out %bin, $(EXT_SUBDIRS))
 
 include kaldi.mk

--- a/src/configure
+++ b/src/configure
@@ -65,12 +65,12 @@ Configuration options:
   --cudatk-dir=DIR      CUDA toolkit directory
   --double-precision    Build with BaseFloat set to double if yes [default=no],
                         mostly useful for testing purposes.
-  --static-fst          Build with static OpenFst libraries [default=yes]
+  --static-fst          Build with static OpenFst libraries [default=no]
   --fst-root=DIR        OpenFst root directory [default=../tools/openfst/]
   --fst-version=STR     OpenFst version string
   --mathlib=LIB         Math library [default=ATLAS]
                         Supported libraries: ATLAS, MKL, CLAPACK, OPENBLAS.
-  --static-math         Build with static math libraries [default=yes]
+  --static-math         Build with static math libraries [default=no]
   --threaded-math       Build with multi-threaded math libraries [default=no]
   --threaded-atlas      Build with multi-threaded ATLAS libraries [default=no]
   --atlas-root=DIR      ATLAS root directory [default=../tools/ATLAS/]
@@ -842,8 +842,8 @@ ENV_LDLIBS=$LDLIBS
 double_precision=false
 dynamic_kaldi=false
 use_cuda=true
-static_fst=true
-static_math=true
+static_fst=false
+static_math=false
 threaded_atlas=false
 mkl_threading=sequential
 android=false

--- a/src/configure
+++ b/src/configure
@@ -65,12 +65,12 @@ Configuration options:
   --cudatk-dir=DIR      CUDA toolkit directory
   --double-precision    Build with BaseFloat set to double if yes [default=no],
                         mostly useful for testing purposes.
-  --static-fst          Build with static OpenFst libraries [default=no]
+  --static-fst          Build with static OpenFst libraries [default=yes]
   --fst-root=DIR        OpenFst root directory [default=../tools/openfst/]
   --fst-version=STR     OpenFst version string
   --mathlib=LIB         Math library [default=ATLAS]
                         Supported libraries: ATLAS, MKL, CLAPACK, OPENBLAS.
-  --static-math         Build with static math libraries [default=no]
+  --static-math         Build with static math libraries [default=yes]
   --threaded-math       Build with multi-threaded math libraries [default=no]
   --threaded-atlas      Build with multi-threaded ATLAS libraries [default=no]
   --atlas-root=DIR      ATLAS root directory [default=../tools/ATLAS/]
@@ -842,8 +842,8 @@ ENV_LDLIBS=$LDLIBS
 double_precision=false
 dynamic_kaldi=false
 use_cuda=true
-static_fst=false
-static_math=false
+static_fst=true
+static_math=true
 threaded_atlas=false
 mkl_threading=sequential
 android=false

--- a/src/configure
+++ b/src/configure
@@ -424,11 +424,8 @@ function configure_cuda {
     fi
 
     case $CUDA_VERSION in
-      5_5) CUDA_ARCH="-gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35" ;;
-      6_*) CUDA_ARCH="-gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50" ;;
-      7_*) CUDA_ARCH="-gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_53,code=sm_53" ;;
-      8_*) CUDA_ARCH="-gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62" ;;
-      9_*) CUDA_ARCH="-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_53,code=sm_53 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62 -gencode arch=compute_70,code=sm_70" ;;
+      8_*) CUDA_ARCH="-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62" ;;
+      9_*) CUDA_ARCH="-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62 -gencode arch=compute_70,code=sm_70" ;;
       *) echo "Unsupported CUDA_VERSION (CUDA_VERSION=$CUDA_VERSION), please report it to Kaldi mailing list, together with 'nvcc -h' or 'ptxas -h' which lists allowed -gencode values..."; exit 1 ;;
     esac
 

--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -10,4 +10,4 @@ CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 64 -DHAVE_CUDA \
              -ccbin $(CXX) -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION)
 CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
-CUDA_LDLIBS += -lcublas -lcudart -lcurand #LDLIBS : The libs are loaded later than static libs in implicit rule
+CUDA_LDLIBS += -lcublas_static -lcudart_static -lcurand_static -lculibos -lrt #LDLIBS : The libs are loaded later than static libs in implicit rule

--- a/src/makefiles/cuda_64bit.mk
+++ b/src/makefiles/cuda_64bit.mk
@@ -10,4 +10,4 @@ CUDA_FLAGS = -g -Xcompiler -fPIC --verbose --machine 64 -DHAVE_CUDA \
              -ccbin $(CXX) -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION)
 CXXFLAGS += -DHAVE_CUDA -I$(CUDATKDIR)/include
 CUDA_LDFLAGS += -L$(CUDATKDIR)/lib64 -Wl,-rpath,$(CUDATKDIR)/lib64
-CUDA_LDLIBS += -lcublas_static -lcudart_static -lcurand_static -lculibos -lrt #LDLIBS : The libs are loaded later than static libs in implicit rule
+CUDA_LDLIBS += -lcublas -lcudart -lcurand #LDLIBS : The libs are loaded later than static libs in implicit rule

--- a/src/makefiles/linux_openblas.mk
+++ b/src/makefiles/linux_openblas.mk
@@ -22,11 +22,9 @@ CXXFLAGS = -std=c++11 -I.. -I$(OPENFSTINC) $(EXTRA_CXXFLAGS) \
            -DKALDI_DOUBLEPRECISION=$(DOUBLE_PRECISION) \
            -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_OPENBLAS -I$(OPENBLASINC) \
            -msse -msse2 -pthread \
-           -g # -O0 -DKALDI_PARANOID
+           -g -O3 # -O0 -DKALDI_PARANOID
 
-ifeq ($(KALDI_FLAVOR), dynamic)
 CXXFLAGS += -fPIC
-endif
 
 # Compiler specific flags
 COMPILER = $(shell $(CXX) -v 2>&1)

--- a/src/online2/online2-nnet3-latgen-i2x-wrapper.h
+++ b/src/online2/online2-nnet3-latgen-i2x-wrapper.h
@@ -13,6 +13,8 @@ using kaldi::DecoderImpl;
 
 struct RecognitionResult {
   std::string transcript;
+  bool is_final = false;
+  bool error = false;
 };
 
 class Decoder {
@@ -21,13 +23,15 @@ class Decoder {
 
   // Feed PCM SI16 data into the decoder.
   // Returns 0 on success, error code otherwise.
-  // If called with length == 0, the decoder is finalized and no further calls are allowed.
   int32_t FeedBytestring(const std::string& bytestring);
 
-  // Puts the final recognition result in the string passed by pointer.
-  // Frees the resources and destroys the recognition session.
-  // Returns 0 on success, error code otherwise.
-  int32_t GetResultAndFinalize(RecognitionResult *recognition_result);
+  // Finalize the decoder, signaling no more data will be available.
+  // Does not free the resources.
+  // Further calls to FeedBytestring will be ignored and return error code.
+  int32_t Finalize();
+
+  // Return recognition result.
+  const RecognitionResult GetResult();
  private:
   DecoderImpl *decoder_impl_ = nullptr;
   Decoder(DecoderImpl *decoder_impl_);

--- a/src/online2/online2-nnet3-latgen-i2x-wrapper.h
+++ b/src/online2/online2-nnet3-latgen-i2x-wrapper.h
@@ -13,6 +13,8 @@ using kaldi::DecoderImpl;
 
 struct RecognitionResult {
   std::string transcript;
+  uint32_t num_frames = 0;
+  double mean_frame_likelihood = 0.0;
   bool is_final = false;
   bool error = false;
 };

--- a/src/online2/online2-nnet3-latgen-i2x-wrapper.h
+++ b/src/online2/online2-nnet3-latgen-i2x-wrapper.h
@@ -31,7 +31,12 @@ class Decoder {
   int32_t Finalize();
 
   // Return recognition result.
+  // Will return partial result if the decoder is not yet finalized.
   const RecognitionResult GetResult();
+
+  // Frees the internal memory structures.
+  // All further calls to this Decoder object will be ignored and return error code.
+  void InvalidateAndFree();
  private:
   DecoderImpl *decoder_impl_ = nullptr;
   Decoder(DecoderImpl *decoder_impl_);

--- a/src/online2_py/Makefile
+++ b/src/online2_py/Makefile
@@ -9,25 +9,28 @@ $(SWIG_PYTHON_BINDING_NAME)_wrap.cc: $(SWIG_PYTHON_BINDING_NAME).i
 	mv $(SWIG_PYTHON_BINDING_NAME)_wrap.cxx $(SWIG_PYTHON_BINDING_NAME)_wrap.cc
 
 include ../kaldi.mk
+LDFLAGS += $(CUDA_LDFLAGS)
+LDLIBS += $(CUDA_LDLIBS)
 
 TESTFILES =
 
 OBJFILES = $(SWIG_PYTHON_BINDING_NAME)_wrap.o
 
-ADDLIBS = ../ivector/kaldi-ivector.a ../nnet3/kaldi-nnet3.a \
+ADDLIBS = ../online2/kaldi-online2.a \
+          ../ivector/kaldi-ivector.a ../nnet3/kaldi-nnet3.a \
           ../chain/kaldi-chain.a ../nnet2/kaldi-nnet2.a \
           ../cudamatrix/kaldi-cudamatrix.a ../decoder/kaldi-decoder.a \
           ../lat/kaldi-lat.a ../hmm/kaldi-hmm.a ../feat/kaldi-feat.a \
           ../transform/kaldi-transform.a ../gmm/kaldi-gmm.a \
           ../tree/kaldi-tree.a ../util/kaldi-util.a \
           ../matrix/kaldi-matrix.a ../base/kaldi-base.a \
-          ../fstext/kaldi-fstext.a ../online2/kaldi-online2.a
+          ../fstext/kaldi-fstext.a
 
 
 include ../makefiles/default_rules.mk
 
 all: _$(SWIG_PYTHON_BINDING_NAME).so
 
-_$(SWIG_PYTHON_BINDING_NAME).so: $(OBJFILES)
-	$(CXX) -shared -o $@ $(OBJFILES) $(LDFLAGS) $(LDLIBS)
-	ln -sf $(shell pwd)/$@ $(KALDILIBDIR)/$@
+_$(SWIG_PYTHON_BINDING_NAME).so: $(OBJFILES) $(ADDLIBS)
+	$(CXX) -shared -o $@ $(OBJFILES) $(LDFLAGS) $(ADDLIBS) $(LDLIBS)
+

--- a/src/online2_py/Makefile
+++ b/src/online2_py/Makefile
@@ -5,7 +5,7 @@ SWIG_PYTHON_BINDING_NAME = online2_nnet3_latgen_i2x_wrapper
 EXTRA_CXXFLAGS += -I/usr/include/python3.5
 
 $(SWIG_PYTHON_BINDING_NAME)_wrap.cc: $(SWIG_PYTHON_BINDING_NAME).i
-	../../tools/swig/build/bin/swig -c++ -python $(SWIG_PYTHON_BINDING_NAME).i
+	../../tools/swig/build/bin/swig -c++ -python -py3 $(SWIG_PYTHON_BINDING_NAME).i
 	mv $(SWIG_PYTHON_BINDING_NAME)_wrap.cxx $(SWIG_PYTHON_BINDING_NAME)_wrap.cc
 
 include ../kaldi.mk

--- a/src/online2_py/Makefile
+++ b/src/online2_py/Makefile
@@ -4,7 +4,7 @@ all:
 SWIG_PYTHON_BINDING_NAME = online2_nnet3_latgen_i2x_wrapper
 EXTRA_CXXFLAGS += -I/usr/include/python3.5
 
-$(SWIG_PYTHON_BINDING_NAME)_wrap.cc: $(SWIG_PYTHON_BINDING_NAME).i
+$(SWIG_PYTHON_BINDING_NAME)_wrap.cc: $(SWIG_PYTHON_BINDING_NAME).i ../online2/online2-nnet3-latgen-i2x-wrapper.h
 	../../tools/swig/build/bin/swig -c++ -python -py3 $(SWIG_PYTHON_BINDING_NAME).i
 	mv $(SWIG_PYTHON_BINDING_NAME)_wrap.cxx $(SWIG_PYTHON_BINDING_NAME)_wrap.cc
 
@@ -36,4 +36,4 @@ all: _$(SWIG_PYTHON_BINDING_NAME).so
 _$(SWIG_PYTHON_BINDING_NAME).so: $(SWIG_PYTHON_BINDING_NAME).py $(OBJFILES) $(ADDLIBS)
 	$(CXX) -shared -o $@ $(OBJFILES) $(LDFLAGS) $(ADDLIBS) $(LDLIBS)
 
-$(SWIG_PYTHON_BINDING_NAME).py: $(OBJFILES) $(ADDLIBS)
+$(SWIG_PYTHON_BINDING_NAME).py: $(SWIG_PYTHON_BINDING_NAME)_wrap.cc

--- a/src/online2_py/Makefile
+++ b/src/online2_py/Makefile
@@ -8,6 +8,8 @@ $(SWIG_PYTHON_BINDING_NAME)_wrap.cc: $(SWIG_PYTHON_BINDING_NAME).i
 	../../tools/swig/build/bin/swig -c++ -python -py3 $(SWIG_PYTHON_BINDING_NAME).i
 	mv $(SWIG_PYTHON_BINDING_NAME)_wrap.cxx $(SWIG_PYTHON_BINDING_NAME)_wrap.cc
 
+depend: $(SWIG_PYTHON_BINDING_NAME)_wrap.cc
+
 include ../kaldi.mk
 LDFLAGS += $(CUDA_LDFLAGS)
 LDLIBS += $(CUDA_LDLIBS)
@@ -31,6 +33,7 @@ include ../makefiles/default_rules.mk
 
 all: _$(SWIG_PYTHON_BINDING_NAME).so
 
-_$(SWIG_PYTHON_BINDING_NAME).so: $(OBJFILES) $(ADDLIBS)
+_$(SWIG_PYTHON_BINDING_NAME).so: $(SWIG_PYTHON_BINDING_NAME).py $(OBJFILES) $(ADDLIBS)
 	$(CXX) -shared -o $@ $(OBJFILES) $(LDFLAGS) $(ADDLIBS) $(LDLIBS)
 
+$(SWIG_PYTHON_BINDING_NAME).py: $(OBJFILES) $(ADDLIBS)

--- a/src/online2_py/online2_nnet3_latgen_i2x_wrapper.i
+++ b/src/online2_py/online2_nnet3_latgen_i2x_wrapper.i
@@ -11,5 +11,7 @@
 %include std_string.i
 using std::string;
 %newobject DecoderFactory::StartDecodingSession();
+
+%feature("autodoc", "3");
 %include "../online2/online2-nnet3-latgen-i2x-wrapper.h"
 

--- a/src/online2_py/smoke_test.py
+++ b/src/online2_py/smoke_test.py
@@ -1,5 +1,11 @@
+#!/usr/bin/env python3
+
 import online2_nnet3_latgen_i2x_wrapper as m
+
 import numpy
+import random
+import timeit
+import wave
 
 wavefile = numpy.random.randint(low=-2**15, high=2**15, size=16000*10, dtype=numpy.int16)
 dfactory = m.DecoderFactory(b"../online2bin/resourcedir/")
@@ -10,13 +16,26 @@ rr = m.RecognitionResult()
 decoder.GetResultAndFinalize(rr.this)
 print(str(rr.transcript, 'utf8'))
 
-import wave
 f = open(b"/home/christoph/data/transcription/to_transcribe2/16khz/e9603e8f814dbe98d233b04af040ad3154f689c34128026a7b93bbd8924b8623.webm.wav", 'rb')
 w = wave.open(f)
 www = w.readframes(w.getnframes())
-decoder = dfactory.StartDecodingSession()
-decoder.FeedBytestring(www)
-decoder.FeedBytestring(b"")
+
+def run_decoding():
+    decoder = dfactory.StartDecodingSession()
+    i = 0
+    while i < len(www):
+        chunk_length = random.randint(1, 200)
+        decoder.FeedBytestring(www[i:i+chunk_length])
+        i += chunk_length
+    decoder.FeedBytestring(b"")
+    return decoder
+
+decoder = run_decoding()
 rr = m.RecognitionResult()
 decoder.GetResultAndFinalize(rr.this)
 print(str(rr.transcript, 'utf8'))
+
+NUM = 3
+elapsed = timeit.repeat("run_decoding()", setup="from __main__ import run_decoding", number=1, repeat=NUM)
+length = w.getnframes() / w.getframerate()
+print("Elapsed: {}, Sound length: {}, best-case RTF: {}".format(elapsed, length, min(elapsed) / length))

--- a/src/online2_py/smoke_test.py
+++ b/src/online2_py/smoke_test.py
@@ -11,31 +11,32 @@ wavefile = numpy.random.randint(low=-2**15, high=2**15, size=16000*10, dtype=num
 dfactory = m.DecoderFactory(b"../online2bin/resourcedir/")
 decoder = dfactory.StartDecodingSession()
 decoder.FeedBytestring(wavefile.tostring())
-decoder.FeedBytestring(b"")
-rr = m.RecognitionResult()
-decoder.GetResultAndFinalize(rr.this)
+decoder.Finalize()
+rr = decoder.GetResult()
 print(str(rr.transcript, 'utf8'))
 
 f = open(b"/home/christoph/data/transcription/to_transcribe2/16khz/e9603e8f814dbe98d233b04af040ad3154f689c34128026a7b93bbd8924b8623.webm.wav", 'rb')
 w = wave.open(f)
 www = w.readframes(w.getnframes())
 
-def run_decoding():
+def run_decoding(partial, low=1, high=200):
     decoder = dfactory.StartDecodingSession()
     i = 0
     while i < len(www):
-        chunk_length = random.randint(1, 200)
+        chunk_length = random.randint(low, high)
         decoder.FeedBytestring(www[i:i+chunk_length])
+        if partial:
+            result = decoder.GetResult()
+            print(str(result.transcript, 'utf8'))
         i += chunk_length
-    decoder.FeedBytestring(b"")
+    decoder.Finalize()
     return decoder
 
-decoder = run_decoding()
-rr = m.RecognitionResult()
-decoder.GetResultAndFinalize(rr.this)
+decoder = run_decoding(partial=True, high=16000)
+rr = decoder.GetResult()
 print(str(rr.transcript, 'utf8'))
 
 NUM = 3
-elapsed = timeit.repeat("run_decoding()", setup="from __main__ import run_decoding", number=1, repeat=NUM)
+elapsed = timeit.repeat("run_decoding(partial=False)", setup="from __main__ import run_decoding", number=1, repeat=NUM)
 length = w.getnframes() / w.getframerate()
 print("Elapsed: {}, Sound length: {}, best-case RTF: {}".format(elapsed, length, min(elapsed) / length))

--- a/src/online2_py/smoke_test.py
+++ b/src/online2_py/smoke_test.py
@@ -7,34 +7,41 @@ import random
 import timeit
 import wave
 
+
+def printRecoResult(rr):
+    print("[ num frames = '{:5d}', average per-frame likelihood = {:02.3f} ], {}".format(
+        rr.num_frames, rr.mean_frame_likelihood, str(rr.transcript, 'utf8')))
+
 wavefile = numpy.random.randint(low=-2**15, high=2**15, size=16000*10, dtype=numpy.int16)
 dfactory = m.DecoderFactory(b"../online2bin/resourcedir/")
 decoder = dfactory.StartDecodingSession()
 decoder.FeedBytestring(wavefile.tostring())
 decoder.Finalize()
 rr = decoder.GetResult()
-print(str(rr.transcript, 'utf8'))
+printRecoResult(rr)
 
 f = open(b"/home/christoph/data/transcription/to_transcribe2/16khz/e9603e8f814dbe98d233b04af040ad3154f689c34128026a7b93bbd8924b8623.webm.wav", 'rb')
 w = wave.open(f)
-www = w.readframes(w.getnframes())
+w_samples = w.readframes(w.getnframes())
 
 def run_decoding(partial, low=1, high=200):
     decoder = dfactory.StartDecodingSession()
     i = 0
-    while i < len(www):
+    while i < len(w_samples):
         chunk_length = random.randint(low, high)
-        decoder.FeedBytestring(www[i:i+chunk_length])
+        decoder.FeedBytestring(w_samples[i:i+chunk_length])
         if partial:
             result = decoder.GetResult()
-            print(str(result.transcript, 'utf8'))
+            printRecoResult(result)
         i += chunk_length
     decoder.Finalize()
     return decoder
 
-decoder = run_decoding(partial=True, high=16000)
+decoder = run_decoding(partial=True, low=100, high=16000)
+decoder.Finalize()
 rr = decoder.GetResult()
-print(str(rr.transcript, 'utf8'))
+decoder.InvalidateAndFree()
+printRecoResult(rr)
 
 NUM = 3
 elapsed = timeit.repeat("run_decoding(partial=False)", setup="from __main__ import run_decoding", number=1, repeat=NUM)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -18,7 +18,7 @@ ifeq ("$(shell expr $(OPENFST_VER_NUM) \< 10600)","1")
             Supported versions: >= 1.6.0)
 endif
 
-all: check_required_programs sph2pipe sclite openfst swig
+all: check_required_programs sph2pipe sclite openfst swig openblas
 	@echo -e "\n\n"
 	@echo "Warning: IRSTLM is not installed by default anymore. If you need IRSTLM"
 	@echo "Warning: use the script extras/install_irstlm.sh"
@@ -30,17 +30,17 @@ sph2pipe sclite openfst sctk: | check_required_programs
 check_required_programs:
 	extras/check_dependencies.sh
 
-clean: openfst_cleaned sclite_cleaned swig_cleaned
+clean: openfst_cleaned sclite_cleaned swig_cleaned openblas_cleaned
 
 swig_cleaned:
-	$(MAKE) -C swig clean
+	[ ! -e swig ] || $(MAKE) -C swig clean
 
 openfst_cleaned:
-	$(MAKE) -C openfst-$(OPENFST_VERSION) clean
+	[ ! -e openfst-$(OPENFST_VERSION) ] || $(MAKE) -C openfst-$(OPENFST_VERSION) clean
 
 
 sclite_cleaned:
-	$(MAKE) -C sctk clean
+	[ ! -e sctk ] || $(MAKE) -C sctk clean
 
 distclean:
 	rm -rf openfst-$(OPENFST_VERSION)/
@@ -81,6 +81,8 @@ else
   openfst_add_CXXFLAGS =
 endif
 
+openfst_add_CXXFLAGS += -fPIC -O3
+
 openfst-$(OPENFST_VERSION)/Makefile: openfst-$(OPENFST_VERSION) | check_required_programs
 	cd openfst-$(OPENFST_VERSION)/ && \
 	./configure --prefix=`pwd` $(OPENFST_CONFIGURE) CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS) $(openfst_add_CXXFLAGS)" LDFLAGS="$(LDFLAGS)" LIBS="-ldl"
@@ -90,8 +92,8 @@ openfst-$(OPENFST_VERSION): openfst-$(OPENFST_VERSION).tar.gz
 	tar xozf openfst-$(OPENFST_VERSION).tar.gz
 
 openfst-$(OPENFST_VERSION).tar.gz:
-	wget -T 10 -t 1 http://openfst.cs.nyu.edu/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
-	wget -T 10 -t 3 http://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz
+	wget --retry-connrefused  -T 10 -t 1 http://openfst.cs.nyu.edu/twiki/pub/FST/FstDownload/openfst-$(OPENFST_VERSION).tar.gz || \
+	wget --retry-connrefused -T 10 -t 3 http://www.openslr.org/resources/2/openfst-$(OPENFST_VERSION).tar.gz
 
 sclite: sclite_compiled
 
@@ -113,8 +115,8 @@ sctk: sctk-2.4.10-20151007-1312Z.tar.bz2
 	rm -rf sctk && ln -s sctk-2.4.10 sctk
 
 sctk-2.4.10-20151007-1312Z.tar.bz2:
-	wget -T 10 -t 3 ftp://jaguar.ncsl.nist.gov/pub/sctk-2.4.10-20151007-1312Z.tar.bz2|| \
-	wget --no-check-certificate -T 10 http://www.openslr.org/resources/4/sctk-2.4.10-20151007-1312Z.tar.bz2
+	wget --retry-connrefused -T 10 -t 3 ftp://jaguar.ncsl.nist.gov/pub/sctk-2.4.10-20151007-1312Z.tar.bz2|| \
+	wget --retry-connrefused --no-check-certificate -T 10 http://www.openslr.org/resources/4/sctk-2.4.10-20151007-1312Z.tar.bz2
 
 sph2pipe: sph2pipe_compiled
 
@@ -128,8 +130,11 @@ sph2pipe_v2.5: sph2pipe_v2.5.tar.gz
 	tar xzf sph2pipe_v2.5.tar.gz
 
 sph2pipe_v2.5.tar.gz:
-	wget -T 10 -t 3 http://www.openslr.org/resources/3/sph2pipe_v2.5.tar.gz || \
-	wget --no-check-certificate -T 10  https://sourceforge.net/projects/kaldi/files/sph2pipe_v2.5.tar.gz
+	wget --retry-connrefused -T 10 -t 3 http://www.openslr.org/resources/3/sph2pipe_v2.5.tar.gz || \
+	wget --retry-connrefused --no-check-certificate -T 10  https://sourceforge.net/projects/kaldi/files/sph2pipe_v2.5.tar.gz
+
+openblas_cleaned:
+	rm -rf OpenBLAS
 
 openblas: openblas_compiled
 
@@ -153,11 +158,11 @@ openblas_compiled:
 	-git clone https://github.com/xianyi/OpenBLAS.git
 	-cd OpenBLAS; git pull
 	cd OpenBLAS; sed 's:# FCOMMON_OPT = -frecursive:FCOMMON_OPT = -frecursive:' < Makefile.rule >tmp && mv tmp Makefile.rule
-	# $(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=1 NUM_THREADS=64 -C OpenBLAS all install
-	$(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) DEBUG=1 USE_THREAD=0 -C OpenBLAS all install
+	# $(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) USE_THREAD=1 NUM_THREADS=64 -C OpenBLAS all install
+	$(MAKE) PREFIX=`pwd`/OpenBLAS/install FC=gfortran $(fortran_opt) USE_THREAD=0 -C OpenBLAS all install
 
 swig-3.0.12.tar.gz:
-	wget -T 10 -t 3 http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz
+	wget --retry-connrefused -T 10 -t 3 http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz
 
 swig: swig-3.0.12.tar.gz
 	tar xvf swig-3.0.12.tar.gz


### PR DESCRIPTION
1) Switch linear algebra to OpenBLAS. Enable optimizations (-O3) for OpenFST and Kaldi builds.
2) Add a `build.sh` script as a single entrypoint for building the system. If supplied with `--deploy` option, will build only the online2_py shared library, with all kaldi/openfst/openblas dependencies linked statically (and CUDA switched off). A stripped version of this library has size under 8 MB.
3) Drop support for older versions of CUDA and older NVidia GPUs (this makes the build faster and binaries slimmer).